### PR TITLE
fix: Use file-relative paths in contract tests

### DIFF
--- a/tests/test_identity_contract.py
+++ b/tests/test_identity_contract.py
@@ -13,8 +13,8 @@ from pathlib import Path
 
 def test_identity_consistency_version_json_vs_manifest():
     """Agent identity must be consistent across version.json and agent_manifest.yaml."""
-    version_file = Path(".aget/version.json")
-    manifest_file = Path(".aget/collaboration/agent_manifest.yaml")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
+    manifest_file = Path(__file__).parent.parent / ".aget/collaboration/agent_manifest.yaml"
 
     assert version_file.exists(), "version.json not found"
 
@@ -39,7 +39,7 @@ def test_identity_consistency_version_json_vs_manifest():
 
 def test_identity_no_conflation_with_directory_name():
     """Agent name in version.json must match directory name (identity = location)."""
-    version_file = Path(".aget/version.json")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
     assert version_file.exists(), "version.json not found"
 
     with open(version_file) as f:
@@ -48,14 +48,14 @@ def test_identity_no_conflation_with_directory_name():
         if "agent_name" in data:
             agent_name = data["agent_name"]
             # Get directory name
-            repo_dir = Path.cwd().name
+            repo_dir = Path(__file__).parent.parent.name
             assert agent_name == repo_dir, \
                 f"Identity conflation detected: agent_name='{agent_name}' but directory='{repo_dir}'"
 
 
 def test_identity_persistence_across_invocations():
     """Agent identity fields must not change between invocations (stable identity)."""
-    version_file = Path(".aget/version.json")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
     assert version_file.exists(), "version.json not found"
 
     with open(version_file) as f:

--- a/tests/test_wake_contract.py
+++ b/tests/test_wake_contract.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 def test_wake_protocol_reports_agent_name():
     """Wake protocol must report agent name from version.json (if present)."""
-    version_file = Path(".aget/version.json")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
     assert version_file.exists(), "version.json not found"
 
     with open(version_file) as f:
@@ -26,7 +26,7 @@ def test_wake_protocol_reports_agent_name():
 
 def test_wake_protocol_reports_version():
     """Wake protocol must report current AGET version."""
-    version_file = Path(".aget/version.json")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
     assert version_file.exists(), "version.json not found"
 
     with open(version_file) as f:
@@ -40,7 +40,7 @@ def test_wake_protocol_reports_version():
 
 def test_wake_protocol_reports_capabilities():
     """Wake protocol must report agent capabilities (if present)."""
-    version_file = Path(".aget/version.json")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
     assert version_file.exists(), "version.json not found"
 
     with open(version_file) as f:
@@ -53,7 +53,7 @@ def test_wake_protocol_reports_capabilities():
 
 def test_wake_protocol_reports_domain():
     """Wake protocol must report agent domain for context (if present)."""
-    version_file = Path(".aget/version.json")
+    version_file = Path(__file__).parent.parent / ".aget/version.json"
     assert version_file.exists(), "version.json not found"
 
     with open(version_file) as f:


### PR DESCRIPTION
## Problem

CI failing with 7 contract test failures:
- `test_identity_contract.py` (3 tests)
- `test_wake_contract.py` (4 tests)

**Root cause**: `test_backup_rollback.py` + coverage causes CWD deletion
- TemporaryDirectory cleanup while pytest in that directory
- `os.getcwd()` raises `FileNotFoundError`
- Relative `Path('.aget/version.json')` fails

## Solution

Use file-relative paths instead of cwd-relative paths:

```python
# OLD (cwd-relative, breaks when CWD deleted)
version_file = Path(".aget/version.json")

# NEW (file-relative, robust to CWD changes)
version_file = Path(__file__).parent.parent / ".aget/version.json"
```

## Changes

- `tests/test_identity_contract.py`: Fixed 3 tests
- `tests/test_wake_contract.py`: Fixed 4 tests
- Also fixed `Path.cwd().name` → `Path(__file__).parent.parent.name`

## Verification

✅ All 280 tests pass locally with full coverage:
```bash
pytest tests/ -v --cov=. --cov-report=term
# 280 passed, 1 warning in 10.62s
```

## Investigation

Full analysis in Gate 1/2A/2 investigation:
1. Reproduced failure locally with full test suite + coverage
2. Identified `test_backup_rollback.py` as pollution source
3. Confirmed CWD deletion via `FileNotFoundError` in debug test
4. Applied file-relative path fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)